### PR TITLE
add M_OBJECT_AUTOLOADSAVE macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,22 @@ check doxygen docs or see the comments directly in the source file(s).
 
 ### MMetaConfig
 
-This is flavor of config class that is designed for easy generation of ui for editing values of config.
-Basic editor is provided under the name MMetaConfigEditor. To use it in project add `CONFIG += mconfig-editors`
-before including mconfig.pri file.
+QObject-based version of config that can be easily used in QML code. This class is designed for automatic  generation of ui for editing values of config. 
+For apps using qt widgets basic editors are provided under the name MMetaConfigEditor. 
 
+Usage:
+* cmake: set mconfig-editors option to ON
+* qmake: `CONFIG += mconfig-editors` (before including mconfig.pri file)
 
 ### Encryption
 
-It is possible to encrypt your config file! To enable it simply add MCrypto library to your project:
-for qmake ```include(mcrypto.pri)``` or for cmake ```add_subdirectory(/your-path-to-mcdb/mcrypto mcrypto))```.
-Then you can enable build option called **mconfig-mcrypto**.
+It is possible to encrypt your config file using MCrypto library.
+
+Usage:
+1. add mcrypto
+	* qmake `include(mcrypto.pri)` 
+	* cmake `add_subdirectory(/your-path-to-mcdb/mcrypto mcrypto))`
+1. enable build option called **mconfig-mcrypto**.
 
 # License
 

--- a/examples/exampleconfig_with_editor/CMakeLists.txt
+++ b/examples/exampleconfig_with_editor/CMakeLists.txt
@@ -1,6 +1,5 @@
 if (mconfig-editors)
   set(CMAKE_AUTOMOC ON)
-  #set(mconfig-editors ON)
   add_executable(exampleconfig_with_editor exampleconfig.h main.cpp)
   target_link_libraries(exampleconfig_with_editor mconfig)
 

--- a/examples/exampleconfig_with_editor/exampleconfig.h
+++ b/examples/exampleconfig_with_editor/exampleconfig.h
@@ -22,8 +22,7 @@ SOFTWARE.
 *******************************************************************************/
 
 
-#ifndef EXAMPLECONFIG_H
-#define EXAMPLECONFIG_H
+#pragma once
 
 #include "mmetaconfig.h"
 
@@ -37,4 +36,3 @@ class ExampleConfig : public MMetaConfig
     M_MEMBER_V(QByteArray, example_string,  "Milo is great")
 };
 
-#endif // EXAMPLECONFIG_H

--- a/mmetaconfig.cpp
+++ b/mmetaconfig.cpp
@@ -60,7 +60,7 @@ void MMetaConfig::setValue(const QByteArray &name, const QVariant &value)
 
 /*!
  * Gather names of all properties for MBaseConfig.
- * Read only properties defined for this object.
+ * Read only properties defined for this object and subclasses.
  */
 void MMetaConfig::init(const QMetaObject *object)
 {

--- a/mmetaconfig.cpp
+++ b/mmetaconfig.cpp
@@ -21,6 +21,13 @@
  * };
  * \endcode
  *
+ * ### Automatic load and save
+ * It might be useful to have config object load data from QSettings storage on construction and save them on deletion. It can be enabled by replacing macro M_OBJECT with M_OBJECT_AUTOLOADSAVE. 
+ * Config classes designed this way require only header file.
+ * 
+ * QML support
+ * MMetaConfig iherits QObject and every member is declared as Q_PROPERTY. Therefore if you expose QObject pointer to config to qml context you can read and modify all members.
+ *
  * ### Hint on member naming
  * There is no limitation on member names. However MMetaConfigEditor is designed in
  * a way that will replace "_" in name with space (" "). This allow for nice ui generation.

--- a/mmetaconfig.h
+++ b/mmetaconfig.h
@@ -9,21 +9,24 @@
 public:                            \
     object() : MMetaConfig(#object) { init(metaObject()); }
 
+#define M_OBJECT_AUTOLOADSAVE(object) \
+public:                            \
+     object() : MMetaConfig(#object) { init(metaObject()); load(); } \
+    ~object() override { save(); }
+
 //Config member macro
 #define M_MEMBER(type, name) \
 public:                        \
-   type name;                  \
-                               \
+    type name;                  \
 private:                       \
-   Q_PROPERTY(type name MEMBER name)
+    Q_PROPERTY(type name MEMBER name)
 
 //Config member macro - default value
 #define M_MEMBER_V(type, name, value) \
-public:                                 \
-   type name{value};                   \
-                                        \
-private:                                \
-   Q_PROPERTY(type name MEMBER name)
+public:                               \
+    type name{value};                  \
+private:                              \
+    Q_PROPERTY(type name MEMBER name)
 
 class MMetaConfig : public QObject, public MBaseConfig
 {


### PR DESCRIPTION
Convenience macro for object that will automatically load (c-tor) and save (d-tor) values from QSettings. 